### PR TITLE
Adding aria-label to discord icon.

### DIFF
--- a/src/lib/components/layout/header.svelte
+++ b/src/lib/components/layout/header.svelte
@@ -10,7 +10,7 @@
 
 	<ul>
 		<li>
-			<a href="https://discord.com/invite/vM2bagU" target="_blank" rel="noopener noreferrer">
+			<a href="https://discord.com/invite/vM2bagU" target="_blank" rel="noopener noreferrer" aria-label="Join the Learn Build Teach Discord server">
 				<svg
 					class="discord"
 					width="71"


### PR DESCRIPTION
Adding aria-label to discord icon.
I tested using the built-in mac screen reader and it appears to see the label correctly.

fixes #11