### PR TITLE
fix: content missing author's username

### DIFF
--- a/src/lib/stores/sharesStore.ts
+++ b/src/lib/stores/sharesStore.ts
@@ -9,7 +9,7 @@ let adminSharesLoaded: boolean = false;
 export const loadShares = async () => {
 	const { data, error } = await supabase
 		.from('Share')
-		.select('title, description, link, createdAt, imageUrl')
+		.select('title, description, link, createdAt, imageUrl, DiscordUser (username)')
 		.order('createdAt', { ascending: false });
 	if (error) {
 		throw new Error('failed to load shares');
@@ -26,8 +26,8 @@ export const loadAdminShares = async () => {
 	const { data, error } = await supabase
 		.from('Share')
 		.select(
-			`id, title, description, link, 
-    tweeted, emailed, tweetable, emailable, userId, createdAt, imageUrl, 
+			`id, title, description, link,
+    tweeted, emailed, tweetable, emailable, userId, createdAt, imageUrl,
     DiscordUser (username)`
 		)
 		.order('createdAt', { ascending: false });


### PR DESCRIPTION
Fixes the missing username for content when viewed on the public page instead of the admin dashboard.

![image](https://user-images.githubusercontent.com/35819660/206312073-de5acd97-81cb-4831-b886-43ef59784c90.png)
